### PR TITLE
Build and deploy directly from netlify.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,31 @@
+[build]
+publish = "public"
+command = "hugo --gc --minify"
+
+[context.production.environment]
+HUGO_VERSION = "0.58.1"
+HUGO_ENV = "production"
+HUGO_ENABLEGITINFO = "true"
+
+[context.split1]
+command = "hugo --gc --minify --enableGitInfo"
+
+[context.split1.environment]
+HUGO_VERSION = "0.58.1"
+HUGO_ENV = "production"
+
+[context.deploy-preview]
+command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
+
+[context.deploy-preview.environment]
+HUGO_VERSION = "0.58.1"
+
+[context.branch-deploy]
+command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
+
+[context.branch-deploy.environment]
+HUGO_VERSION = "ç"
+
+[context.next.environment]
+HUGO_ENABLEGITINFO = "true"
+


### PR DESCRIPTION
In a few months time, [forestry will stop supporting deploy builds](https://forestry.io/docs/hosting/). 

<img width="1176" alt="Screen Shot 2019-09-09 at 6 36 11 PM" src="https://user-images.githubusercontent.com/16350351/64545184-f68f7b00-d330-11e9-85f5-0cc8677672aa.png">

I also noticed that, [for some reason](https://github.com/uracreative/briar-styleguide/issues/4), your forestry build started to fail a while back.

<img width="1176" alt="Screen Shot 2019-09-09 at 6 35 18 PM" src="https://user-images.githubusercontent.com/16350351/64545383-4e2de680-d331-11e9-9ab7-3cd83827b7d8.png">

I added a [netlify build & deploy script](https://github.com/uracreative/briar-styleguide/blob/update/netlify.toml). You can always update the script by checking [this page on hugo docs](https://gohugo.io/hosting-and-deployment/hosting-on-netlify/#configure-hugo-version-in-netlify).

To enable direct builds from netlify, you have to reimport you site and change your build settings. It should be fairly straightforward. If you need my help let me know.

As for forestry, you can keep it cms editing purposes.

